### PR TITLE
fix: updates auth docs link for the workOS, Stytch and Kinde

### DIFF
--- a/docs/02-app/index.mdx
+++ b/docs/02-app/index.mdx
@@ -39,9 +39,9 @@ Here are some common authentication solutions that support the App Router:
 - [Clerk](https://clerk.com/docs/quickstarts/nextjs)
 - [Stack Auth](https://docs.stack-auth.com/getting-started/setup)
 - [Auth0](https://github.com/auth0/nextjs-auth0#app-router)
-- [Stytch](https://stytch.com/docs/example-apps/frontend/nextjs)
-- [Kinde](https://kinde.com/docs/developer-tools/nextjs-sdk/)
-- [WorkOS](https://workos.com/docs/user-management)
+- [Stytch](https://stytch.com/docs/sdks/resources/nextjs)
+- [Kinde](https://docs.kinde.com/developer-tools/sdks/backend/nextjs-sdk/)
+- [WorkOS](https://workos.com/docs/user-management/nextjs)
 - Or manually handling sessions or JWTs
 
 ### How can I set cookies?


### PR DESCRIPTION
current [link](https://workos.com/docs/user-management) for WorkOS point to Node.js document, This update ensures all links lead directly to their respective Next.js integration pages. Also updated link for Stytch and Kinde auth link to point to appropriate docs page.
